### PR TITLE
Quote all paths in platform.txt

### DIFF
--- a/hardware/freedom_e/platform.txt
+++ b/hardware/freedom_e/platform.txt
@@ -15,13 +15,13 @@ compiler.size.cmd=riscv64-unknown-elf-size
 
 
 compiler.sdk.path={runtime.platform.path}/freedom-e-sdk/bsp
-compiler.preproc.flags=-I{build.system.path}/include -I{compiler.sdk.path}/include -I{compiler.sdk.path}/env -I{compiler.sdk.path}/drivers -I{compiler.sdk.path}/env/{build.boardenv}
+compiler.preproc.flags="-I{build.system.path}/include" "-I{compiler.sdk.path}/include" "-I{compiler.sdk.path}/env" "-I{compiler.sdk.path}/drivers" "-I{compiler.sdk.path}/env/{build.boardenv}"
 
 compiler.c.flags=-c -O2 -march={build.mcu} -mabi={build.mabi} -mcmodel={build.mcmodel} -fpeel-loops -ffreestanding -ffunction-sections -fdata-sections -MMD -Wall {compiler.preproc.flags} -include sys/cdefs.h
 
 compiler.cpp.flags=-c -O2 -march={build.mcu} -mabi={build.mabi} -mcmodel={build.mcmodel} -fpeel-loops -ffreestanding -ffunction-sections -fdata-sections -MMD -fpermissive -Wall -fno-rtti -fno-exceptions {compiler.preproc.flags} -include sys/cdefs.h
 
-compiler.ld.flags=-T {build.ldscript} -march={build.mcu} -mabi={build.mabi} -mcmodel={build.mcmodel} -nostartfiles -Xlinker -defsym=__stack_size=0x200 -Wl,-N -Wl,--gc-sections -Wl,--wrap=malloc -Wl,--wrap=free -Wl,--wrap=sbrk
+compiler.ld.flags=-T "{build.ldscript}" -march={build.mcu} -mabi={build.mabi} -mcmodel={build.mcmodel} -nostartfiles -Xlinker -defsym=__stack_size=0x200 -Wl,-N -Wl,--gc-sections -Wl,--wrap=malloc -Wl,--wrap=free -Wl,--wrap=sbrk
 
 compiler.S.flags=-c -march={build.mcu} -mabi={build.mabi} -mcmodel={build.mcmodel} {compiler.preproc.flags}
 
@@ -84,7 +84,7 @@ tools.openocd.cmd=openocd
 tools.openocd.program.params.verbose=-d2
 tools.openocd.program.params.quiet=-d0
 tools.openocd.program.config={runtime.platform.path}/freedom-e-sdk/bsp/env/{build.boardenv}/openocd.cfg
-tools.openocd.program.pattern="{path}{cmd}" -d0 -f {program.config} -c "flash protect 0 64 last off; program {{{build.path}/{build.project_name}.elf}} verify; resume 0x20400000; exit"
+tools.openocd.program.pattern="{path}{cmd}" -d0 -f "{program.config}" -c "flash protect 0 64 last off; program {{{build.path}/{build.project_name}.elf}} verify; resume 0x20400000; exit"
 
 
 tools.manual_openocd.path=
@@ -92,4 +92,4 @@ tools.manual_openocd.cmd=openocd
 tools.manual_openocd.program.params.verbose=-d2
 tools.manual_openocd.program.params.quiet=-d0
 tools.manual_openocd.program.config={runtime.platform.path}/freedom-e-sdk/bsp/env/{build.boardenv}/openocd.cfg
-tools.manual_openocd.program.pattern="{path}{cmd}" -d0 -f {program.config} -c "flash protect 0 64 last off; program {{{build.path}/{build.project_name}.elf}} verify; resume 0x20400000; exit"
+tools.manual_openocd.program.pattern="{path}{cmd}" -d0 -f "{program.config}" -c "flash protect 0 64 last off; program {{{build.path}/{build.project_name}.elf}} verify; resume 0x20400000; exit"


### PR DESCRIPTION
The previous lack of quotes caused compilation and uploads to fail when there was a space in the path.

Reference:
https://forum.arduino.cc/index.php?topic=624160